### PR TITLE
Seite bei Änderungen automatisch aktualisieren

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy changes
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    name: update
+    uses: wei/curl@v1
+    with:
+      args: https://l3p3.de/svr/site-update.txt?site=y4r3


### PR DESCRIPTION
Wenn man nach dieser Änderung Dateien bei GitHub ändert, wird die Seite automatisch aktualisiert und du musst diese site-update.txt nicht mehr selbst aufrufen jedes Mal.